### PR TITLE
Fix log level type in default callback

### DIFF
--- a/liblouisutdml/logging.c
+++ b/liblouisutdml/logging.c
@@ -127,7 +127,7 @@ lbu_logFile (const char *fileName)
 }
 
 static void
-defaultLogCallback (logLevels level, const char *message)
+defaultLogCallback (int level, const char *message)
 {
   if (message == NULL)
     return;


### PR DESCRIPTION
defaultLogCallback is declared in logging.c, line 63 as taking `int
level`, but then defined on line 130 as taking `logLevels level`.

The declaration (unlike) is correct, because defaultLogCallback is
assigned to variable of type `logcallback` on line 65, and `logcallback`
takes `int`, not `logLevels` (see liblouis' logging.c, line 157).

This should fix compilation errors in Travis for the LCG library -
currently it produces this error when compiling with master version of
liblouisutdml with master version of liblouis:

```
logging.c:130:1: error: conflicting types for ‘defaultLogCallback’
logging.c:63:13: note: previous declaration of ‘defaultLogCallback’ was here
logging.c:63:13: warning: ‘defaultLogCallback’ used but never defined [enabled by default]
```

You can see this error here:
https://travis-ci.org/brailcom/lcg/jobs/103141533#L2641

What is strange is that both LCG's Travis build and liblouisutdml's
Travis build seem to use the same version of gcc (4.6.3) and liblouis
and liblouisutdml (all master), and the compile line to me does not
differ in any aspect that could influence the result.

Please note I have not tested this change. I am making it as an obvious
trivial fix and relying on Travis build of liblouisutdml to verify it
upon submitting a PR.

Patch submitted by [A11Y LTD.](http://accessibility.expert)