### PR TITLE
redefine snprintf no longer supported

### DIFF
--- a/windows/include/config.h
+++ b/windows/include/config.h
@@ -95,7 +95,12 @@ static int isnan (double d) {
 
 #if defined(_MSC_VER)
 #define mkdir(p,m) _mkdir(p)
-#define snprintf _snprintf
+#if _MSC_VER>=1900
+#  define STDC99
+#endif
+#if _MSC_VER<1900
+#  define  snprintf _snprintf
+#endif
 #if _MSC_VER < 1500
 #define vsnprintf(b,c,f,a) _vsnprintf(b,c,f,a)
 #endif


### PR DESCRIPTION
From MSVC 14.0 redefining snprintf to _snprintf does not work but C99 support is supported and is the preferred solution
If an ELSE can be used even better!