### PR TITLE
WriteablePath is again added within liblouisutdml

### DIFF
--- a/tools/file2brl.c
+++ b/tools/file2brl.c
@@ -197,8 +197,8 @@ main (int argc, char **argv)
     whichProc = '0';
   if (logFileName[0] != 0)
   {
-  strcpy (logFileName, lbu_getWriteablePath());
-  strcat (logFileName, "file2brl.log");
+  //strcpy (logFileName, lbu_getWriteablePath());
+  strcpy (logFileName, "file2brl.log");
   }
   if (configSettings != NULL)
     for (k = 0; configSettings[k]; k++)


### PR DESCRIPTION
Removed adding the path for the log file as this is added by liblouisutdml. This occurred in Win32 need to check the other OSs will still function as expected.
