### PR TITLE
Fixes for java detection on macOS

### DIFF
--- a/m4/ax_jni_include_dir.m4
+++ b/m4/ax_jni_include_dir.m4
@@ -1,3 +1,4 @@
+
 # ===========================================================================
 #    http://www.gnu.org/software/autoconf-archive/ax_jni_include_dir.html
 # ===========================================================================
@@ -52,32 +53,32 @@ AC_DEFUN([AX_JNI_INCLUDE_DIR],[
 JNI_INCLUDE_DIRS=""
 
 if test "x$JAVA_HOME" != x; then
-	_JTOPDIR="$JAVA_HOME"
+    _JTOPDIR="$JAVA_HOME"
 else
-	if test "x$JAVAC" = x; then
-		JAVAC=javac
-	fi
-	AC_PATH_PROG([_ACJNI_JAVAC], [$JAVAC], [no])
-	if test "x$_ACJNI_JAVAC" = xno; then
-		AC_MSG_ERROR([cannot find JDK; try setting \$JAVAC or \$JAVA_HOME])
-	fi
-	_ACJNI_FOLLOW_SYMLINKS("$_ACJNI_JAVAC")
-	_JTOPDIR=`echo "$_ACJNI_FOLLOWED" | sed -e 's://*:/:g' -e 's:/[[^/]]*$::'`
+    if test "x$JAVAC" = x; then
+        JAVAC=javac
+    fi
+    AC_PATH_PROG([_ACJNI_JAVAC], [$JAVAC], [no])
+    if test "x$_ACJNI_JAVAC" = xno; then
+        AC_MSG_ERROR([cannot find JDK; try setting \$JAVAC or \$JAVA_HOME])
+    fi
+    _ACJNI_FOLLOW_SYMLINKS("$_ACJNI_JAVAC")
+    _JTOPDIR=`echo "$_ACJNI_FOLLOWED" | sed -e 's://*:/:g' -e 's:/[[^/]]*$::'`
 fi
 
 case "$host_os" in
-        darwin*)        # Apple JDK is in /System. Header files are bunded with Xcode on newer systems.
-                        macos_version=$(sw_vers -productVersion | awk -F. '{print $2}')
-                        if [[ $macos_version > 7 ]]; then
-                            _JINC=$(cd /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*.sdk/System/Library/Frameworks/JavaVM.framework/Headers; pwd)
-                        else
-                            _JINC="/System/Library/Frameworks/JavaVM.framework/Headers"
-                        fi
-                        case "$_JTOPDIR" in
-                        /System/Library/Frameworks/JavaVM.framework/*)
-				            _JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`;;
-                        esac;;
-        *)              _JINC="$_JTOPDIR/include";;
+        darwin*)    # Apple Java files are contained within the Xcode bundle on systems > 10.7.
+                    # On OS 10.7 and earlier, they're located in System/Library/Frameworks/JavaVM.framework.
+            macos_version=$(sw_vers -productVersion | sed -n -e 's/^@<:@0-9@:>@*.\(@<:@0-9@:>@*\).@<:@0-9@:>@*/\1/p')
+            if @<:@ "$macos_version" -gt "7" @:>@; then
+                _JTOPDIR="$(xcrun --show-sdk-path)/System/Library/Frameworks/JavaVM.framework"
+                _JINC="$_JTOPDIR/Headers"
+            else
+                _JTOPDIR="/System/Library/Frameworks/JavaVM.framework"
+                _JINC="$_JTOPDIR/Headers"
+            fi
+            ;;
+        *) JINC="$_JTOPDIR/include";;
 esac
 
 _AS_ECHO_LOG([_JTOPDIR=$_JTOPDIR])
@@ -86,12 +87,12 @@ _AS_ECHO_LOG([_JINC=$_JINC])
 # On OS X 10.8 and later, headers are bundled with Xcode:
 #/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*.sdk/System/Library/Frameworks/JavaVM.framework/Headers
 AC_CHECK_FILE([$_JINC/jni.h],
-	[JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JINC"],
-	[_JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
-	 AC_CHECK_FILE([$_JTOPDIR/include/jni.h],
-		[JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JTOPDIR/include"],
+    [JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JINC"],
+    [_JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
+     AC_CHECK_FILE([$_JTOPDIR/include/jni.h],
+        [JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JTOPDIR/include"],
                 AC_MSG_ERROR([cannot find JDK header files]))
-	])
+    ])
 
 # get the likely subdirectories for system specific java includes
 case "$host_os" in
@@ -101,8 +102,8 @@ darwin*)        _JNI_INC_SUBDIRS="darwin";;
 linux*)         _JNI_INC_SUBDIRS="linux genunix";;
 osf*)           _JNI_INC_SUBDIRS="alpha";;
 solaris*)       _JNI_INC_SUBDIRS="solaris";;
-mingw*)		_JNI_INC_SUBDIRS="win32";;
-cygwin*)	_JNI_INC_SUBDIRS="win32";;
+mingw*)     _JNI_INC_SUBDIRS="win32";;
+cygwin*)    _JNI_INC_SUBDIRS="win32";;
 *)              _JNI_INC_SUBDIRS="genunix";;
 esac
 

--- a/m4/ax_jni_include_dir.m4
+++ b/m4/ax_jni_include_dir.m4
@@ -77,7 +77,7 @@ case "$host_os" in
                 _JINC="$_JTOPDIR/Headers"
             fi
             ;;
-        *) JINC="$_JTOPDIR/include";;
+        *) _JINC="$_JTOPDIR/include";;
 esac
 
 _AS_ECHO_LOG([_JTOPDIR=$_JTOPDIR])

--- a/m4/ax_jni_include_dir.m4
+++ b/m4/ax_jni_include_dir.m4
@@ -1,4 +1,3 @@
-
 # ===========================================================================
 #    http://www.gnu.org/software/autoconf-archive/ax_jni_include_dir.html
 # ===========================================================================
@@ -53,17 +52,17 @@ AC_DEFUN([AX_JNI_INCLUDE_DIR],[
 JNI_INCLUDE_DIRS=""
 
 if test "x$JAVA_HOME" != x; then
-    _JTOPDIR="$JAVA_HOME"
+	_JTOPDIR="$JAVA_HOME"
 else
-    if test "x$JAVAC" = x; then
-        JAVAC=javac
-    fi
-    AC_PATH_PROG([_ACJNI_JAVAC], [$JAVAC], [no])
-    if test "x$_ACJNI_JAVAC" = xno; then
-        AC_MSG_ERROR([cannot find JDK; try setting \$JAVAC or \$JAVA_HOME])
-    fi
-    _ACJNI_FOLLOW_SYMLINKS("$_ACJNI_JAVAC")
-    _JTOPDIR=`echo "$_ACJNI_FOLLOWED" | sed -e 's://*:/:g' -e 's:/[[^/]]*$::'`
+	if test "x$JAVAC" = x; then
+		JAVAC=javac
+	fi
+	AC_PATH_PROG([_ACJNI_JAVAC], [$JAVAC], [no])
+	if test "x$_ACJNI_JAVAC" = xno; then
+		AC_MSG_ERROR([cannot find JDK; try setting \$JAVAC or \$JAVA_HOME])
+	fi
+	_ACJNI_FOLLOW_SYMLINKS("$_ACJNI_JAVAC")
+	_JTOPDIR=`echo "$_ACJNI_FOLLOWED" | sed -e 's://*:/:g' -e 's:/[[^/]]*$::'`
 fi
 
 case "$host_os" in
@@ -87,12 +86,12 @@ _AS_ECHO_LOG([_JINC=$_JINC])
 # On OS X 10.8 and later, headers are bundled with Xcode:
 #/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/*.sdk/System/Library/Frameworks/JavaVM.framework/Headers
 AC_CHECK_FILE([$_JINC/jni.h],
-    [JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JINC"],
-    [_JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
-     AC_CHECK_FILE([$_JTOPDIR/include/jni.h],
-        [JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JTOPDIR/include"],
+	[JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JINC"],
+	[_JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
+	 AC_CHECK_FILE([$_JTOPDIR/include/jni.h],
+		[JNI_INCLUDE_DIRS="$JNI_INCLUDE_DIRS $_JTOPDIR/include"],
                 AC_MSG_ERROR([cannot find JDK header files]))
-    ])
+	])
 
 # get the likely subdirectories for system specific java includes
 case "$host_os" in
@@ -102,8 +101,8 @@ darwin*)        _JNI_INC_SUBDIRS="darwin";;
 linux*)         _JNI_INC_SUBDIRS="linux genunix";;
 osf*)           _JNI_INC_SUBDIRS="alpha";;
 solaris*)       _JNI_INC_SUBDIRS="solaris";;
-mingw*)     _JNI_INC_SUBDIRS="win32";;
-cygwin*)    _JNI_INC_SUBDIRS="win32";;
+mingw*)		_JNI_INC_SUBDIRS="win32";;
+cygwin*)	_JNI_INC_SUBDIRS="win32";;
 *)              _JNI_INC_SUBDIRS="genunix";;
 esac
 


### PR DESCRIPTION
These changes to `ax_jni_include_dir.m4` are needed in order to allow Java headers to be properly located on macOS when compiling.

Tested on OS X 10.6 through 10.11. Also tested for regressions on Ubuntu and Windows.

I am also submitting the updated `ax_jni_include_dir` to the Autoconf Archive.

If we're going to do a new release of liblouisutdml in the near-future to support Liblouis 3, it would be great to merge this first.
