### PR TITLE
Fix so footer doesn't stop KeepWithNext working

### DIFF
--- a/liblouisutdml/transcribe_paragraph.c
+++ b/liblouisutdml/transcribe_paragraph.c
@@ -329,6 +329,9 @@ transcribe_paragraph (xmlNode * node, int action)
     case pagenum:
       do_pagenum ();
       break;
+    case footer:
+        keep_with_next = 1;
+        break;
     default:
       break;
     }


### PR DESCRIPTION
Force Footer to have value KeepWithNext=1 so paragraphs which have keepWithNext before footer roll-over to next page.