### PR TITLE
Fix Liblouisutdml incompatibility with newest Liblouis 3.2.0 and future 3.3.0 release

### DIFF
--- a/liblouisutdml/louisutdml.h
+++ b/liblouisutdml/louisutdml.h
@@ -33,7 +33,7 @@
 #define liblouisutdml_h
 #include <libxml/parser.h>
 #include "liblouisutdml.h"
-#include <louis.h>
+#include <internal.h>
 #include "sem_enum.h"
 
 typedef enum

--- a/liblouisutdml/readconfig.c
+++ b/liblouisutdml/readconfig.c
@@ -36,7 +36,7 @@
 #include <stdarg.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <louis.h>
+#include <internal.h>
 #include "louisutdml.h"
 #include "sem_names.h"
 #include <ctype.h>
@@ -241,7 +241,7 @@ findTable (FileInfo * nested)
   if (trialPath[0] == 0)
     {
       if (lou_getTable (nested->value) != NULL)
-	strcpy (trialPath, getLastTableList ());
+	strcpy (trialPath, _lou_getLastTableList());
     }
   if (trialPath[0] == 0)
     {


### PR DESCRIPTION
After Liblouis 3.2.0 release published, Liblouis UTDML master branch version doesn't compiled right.
This little fix solves this issue, based with Liblouis list thread suggestions.
Original Liblouis UTDML source tree when compilation happening, the compiler doesn't founding the „louis.h” header file, and some Liblouis functions names changed since Liblouis 3.2.0 release.
I used the suggested fix since more months my Ubuntu 16.04 based system, and using Liblouis 3.2.0 release.
Without this fix, Liblouis UTDML doesn't compiled my system. When I using the suggested fix, the compilation happening wonderful.

Please review this fix, and if pass this fix the reviewing, please commit this fix into Liblouis UTDML master branch.
