### PR TITLE
hyphenation: fix MIN_NEXT_LINE to 2

### DIFF
--- a/liblouisutdml/transcriber.c
+++ b/liblouisutdml/transcriber.c
@@ -1989,7 +1989,7 @@ hyphenatex (int lastBlank, int lineEnd, int *breakAt, int *insertHyphen)
 
 #define MIN_SYLLABLE_LENGTH 2
 #define MIN_WORD_LENGTH 5
-#define MIN_NEXT_LINE 12
+#define MIN_NEXT_LINE 2
 
   int k;
   char hyphens[MAXNAMELEN];


### PR DESCRIPTION
12 seems like a typo, it's a way too big number, libreoffice uses 2 for
instance.