### PR TITLE
Support automatic page numbering

### DIFF
--- a/lbu_files/document-content.sem
+++ b/lbu_files/document-content.sem
@@ -20,7 +20,7 @@ para p
 no font-face-decls
 no text
 no sequence-decl
-no soft-page-break
+pagebreak soft-page-break
 no automatic-styles
 no body
 no scripts

--- a/liblouisutdml/examine_document.c
+++ b/liblouisutdml/examine_document.c
@@ -81,6 +81,8 @@ examine_document (xmlNode * node)
     case music:
       ud->has_music = 1;
       break;
+    case pagebreak:
+      ud->has_pagebreak = 1;
     default:
       break;
     }

--- a/liblouisutdml/louisutdml.h
+++ b/liblouisutdml/louisutdml.h
@@ -179,6 +179,7 @@ typedef struct
   int has_graphics;
   int has_music;
   int has_cdata;
+  int has_pagebreak;
   Encoding input_encoding;
   Encoding output_encoding;
   Encoding input_text_encoding;
@@ -249,6 +250,7 @@ typedef struct
   BrlPageNumFormat cur_brl_page_num_format;
   int lines_on_page;
   int braille_page_number;
+  int page_number;
   int prelim_pages;
   int paragraphs;
   int braille_pages;

--- a/liblouisutdml/makeContents.c
+++ b/liblouisutdml/makeContents.c
@@ -108,6 +108,8 @@ initialize_contents (void)
     ud->braille_page_number = ud->beginning_braille_page_number;
   else
     ud->braille_page_number = 1;
+  if (ud->has_pagebreak)
+    ud->page_number = 1;
   return 1;
 }
 

--- a/liblouisutdml/readconfig.c
+++ b/liblouisutdml/readconfig.c
@@ -1431,6 +1431,7 @@ read_configuration_file (const char *configFileList, const char
     }
   memset (ud->typeform, 0, sizeof (ud->typeform));
   ud->braille_page_number = ud->beginning_braille_page_number;
+  ud->page_number = 1;
   if (entities)
     strcat (ud->xml_header, "]>\n");
   ud->mode = mode | ud->config_mode;

--- a/liblouisutdml/transcriber.c
+++ b/liblouisutdml/transcriber.c
@@ -71,6 +71,8 @@ static int makeDotsTextNode(xmlNode *node, const widechar *content, int length, 
 static int utd_startLine();
 static int utd_finishLine(int number, int beforeAfter);
 
+static int handlePagenum (xmlChar * printPageNumber, int length);
+
 static void
 initializeTranscriber()
 {
@@ -199,6 +201,12 @@ start_document ()
     ud->braille_page_number = 1;
   else
     ud->braille_page_number = ud->beginning_braille_page_number;
+  if (ud->has_pagebreak)
+    {
+      ud->page_number = 1;
+      /* Prepare first page number */
+      handlePagenum (NULL, 0);
+    }
   ud->outbuf1_len_so_far = 0;
   styleSpec = &prevStyleSpec;
   style = prevStyle = lookup_style ("document");
@@ -1014,9 +1022,16 @@ handlePagenum (xmlChar * printPageNumber, int length)
   int translationLength = MAXNUMLEN - 1;
   widechar translatedBuffer[MAXNUMLEN];
   int translatedLength = MAXNUMLEN;
+  char autoPageNumber[MAXNUMLEN];
   char setup[MAXNAMELEN];
   if (length == 0)
-    return 1;
+    {
+      sprintf (autoPageNumber, "%d", ud->page_number);
+      ud->page_number++;
+      printPageNumber = autoPageNumber;
+    }
+  else if ((printPageNumber[0] >= '0' && printPageNumber[0] <= '9'))
+    ud->page_number = strtol(printPageNumber, NULL, 10);
   strcpy (setup, " ");
   if (!(printPageNumber[0] >= '0' && printPageNumber[0] <= '9'))
     strcat (setup, ud->letsign);


### PR DESCRIPTION
LibreOffice documents do not provide explicit page numbers, but provides
the pagebreak points, so liblouisutdml can simply count the page
numbers.