### PR TITLE
Remove gratuitous debug statements

### DIFF
--- a/java/Jliblouisutdml.c
+++ b/java/Jliblouisutdml.c
@@ -243,11 +243,9 @@ Java_org_liblouis_LibLouisUTDML_backTranslateString (JNIEnv * env,
   if (inbufX == NULL)
     goto release;
   inlen = (*env)->GetArrayLength (env, inbuf);
-  logMessage(LOU_LOG_DEBUG, "inlen=%d", inlen);
   if (outbuf == NULL)
     goto release;
   (*env)->GetIntArrayRegion (env, outlen, 0, 1, &outlenX);
-  logMessage(LOU_LOG_DEBUG, "outlenX=%d", outlenX);
   if (outlenX == EMPTY)
     goto release;
   if (logFile != NULL)
@@ -269,17 +267,14 @@ Java_org_liblouis_LibLouisUTDML_backTranslateString (JNIEnv * env,
     {
       int wcLength;
       int utf8Length;
-      logMessage(LOU_LOG_DEBUG, "After backTranslate outlenX=%d", outlenX);
       if (ud->format_for == utd)
 	{
-          logMessage(LOU_LOG_DEBUG, "Preparing to return UTD");
 	  (*env)->SetByteArrayRegion (env, outbuf, 0, outlenX,
 				      (jbyte *) outbufX);
 	  utf8Length = outlenX;
 	}
       else
 	{
-          logMessage(LOU_LOG_DEBUG, "Preparing to return non-UTD");
 	  wcLength = outlenX;
 	  utf8Length = outlenX;
           outbufY = (jbyte *)malloc(utf8Length);

--- a/liblouisutdml/examine_document.c
+++ b/liblouisutdml/examine_document.c
@@ -42,7 +42,6 @@ examine_document (xmlNode * node)
 {
 /*Examine the parse tree, add semantic attributes and set indicators.*/
   xmlNode *child;
-  logMessage(LOU_LOG_INFO, "Begin examine_document: node->name=%s", node->name);
   if (node == NULL)
     return 0;
   ud->stack[++ud->top] = set_sem_attr (node);
@@ -114,7 +113,6 @@ static void
 examText (xmlNode * node)
 /*We may want to examine text content in the future*/
 {
-  logMessage(LOU_LOG_INFO, "Begin examText: node->content=%s", node->content);
   switch (ud->stack[ud->top])
     {
     case pagenum:
@@ -127,7 +125,6 @@ examText (xmlNode * node)
 static void
 examCdataa (xmlNode * node)
 {
-  logMessage(LOU_LOG_INFO, "Begin examCdata");
   ud->has_cdata = 1;
 }
 

--- a/liblouisutdml/liblouisutdml.c
+++ b/liblouisutdml/liblouisutdml.c
@@ -350,7 +350,6 @@ lbu_backTranslateString (const char *configFileList,
 			 *settingsString, unsigned int mode)
 {
   int k;
-  logMessage(LOU_LOG_INFO, "Begin lbu_backTranslateString: inbuf=%s", inbuf);
   if (!read_configuration_file
       (configFileList, logFileName, settingsString, mode))
     return 0;
@@ -363,7 +362,6 @@ lbu_backTranslateString (const char *configFileList,
   ud->inFile = ud->outFile = NULL;
   if (ud->format_for == utd)
   {
-    logMessage(LOU_LOG_DEBUG, "ud->format_for=utd");
     k = utd_back_translate_braille_string ();
   }
   else
@@ -374,7 +372,6 @@ lbu_backTranslateString (const char *configFileList,
       return 0;
     }
   *outlen = ud->outlen_so_far;
-  logMessage(LOU_LOG_INFO, "Finish lbu_backTranslateString");
   lbu_logEnd ();
   return 1;
 }

--- a/liblouisutdml/makeEndnotes.c
+++ b/liblouisutdml/makeEndnotes.c
@@ -264,7 +264,6 @@ int finish_endnote(xmlNode* node)
 	}
 	else if(endnotePtr != NULL && endnotePtr->has_endnote_pos!=0)
 	{
-		logMessage(LOU_LOG_DEBUG,"finish_endnote:Endnote with id %s already exists",get_attr_value(node));
 		return 0;
 	}
 	else found_endnote=1;
@@ -442,7 +441,6 @@ int link_endnote(xmlNode* node)
 	}
 	else
 	{
-		logMessage(LOU_LOG_DEBUG,"link_endnote:Endnote with id %s already exists",get_attr_value(node));
 		return 0;
 	}
 	

--- a/liblouisutdml/readconfig.c
+++ b/liblouisutdml/readconfig.c
@@ -1313,7 +1313,6 @@ read_configuration_file (const char *configFileList, const char
   char subFile[MAXNAMELEN];
   int listLength;
   int currentListPos = 0;
-  logMessage(LOU_LOG_INFO, "Begin read_configuration_file");
   errorCount = 0;
   fatalErrorCount = 0;
   /*Process logFileName later, after writeablePath is set */
@@ -1474,6 +1473,5 @@ read_configuration_file (const char *configFileList, const char
       ud->back_text = textDevice;
       ud->back_line_length = 70;
     }
-  logMessage(LOU_LOG_INFO, "Finish read_configuration_file");
   return 1;
 }

--- a/liblouisutdml/semantics.c
+++ b/liblouisutdml/semantics.c
@@ -870,7 +870,6 @@ sem_compileFile (const char *fileName)
   lbu_FileInfo nested;
   char completePath[MAXNAMELEN];
   int haveAppended = 0;
-  logMessage(LOU_LOG_INFO, "Begin sem_compileFile: fileName=%s", fileName);
   if (!*fileName)
     return 1;			/*Probably run with defaults */
   if (strncmp (fileName, "appended_", 9) == 0)
@@ -892,7 +891,6 @@ sem_compileFile (const char *fileName)
   memset (&nested, 0, sizeof (nested));
   nested.fileName = fileName;
   nested.unedited = 1;
-  logMessage(LOU_LOG_INFO, "Loading semantic action file: %s", completePath);
   if ((nested.in = fopen ((char *) completePath, "rb")))
     {
       while (getALine (&nested))
@@ -912,7 +910,6 @@ sem_compileFile (const char *fileName)
       return 0;
     }
   numEntries += nested.numEntries;
-  logMessage(LOU_LOG_INFO, "Finish sem_compileFile");
   return 1;
 }
 
@@ -1082,7 +1079,6 @@ printXpathNodes (xmlNodeSetPtr nodes)
   int size;
   int i;
   size = (nodes) ? nodes->nodeNr : 0;
-  logMessage (LOU_LOG_INFO, "Result (%d nodes):", size);
   for (i = 0; i < size; ++i)
     {
       if (nodes->nodeTab[i]->type == XML_NAMESPACE_DECL)
@@ -1231,12 +1227,10 @@ get_sem_attr (xmlNode * node)
   HashEntry *nodeEntry = (HashEntry *) node->_private;
   if (nodeEntry != NULL)
   {
-    logMessage(LOU_LOG_DEBUG, "Node %s has nodeEntry", (const char *)node->name);
     return nodeEntry->semNum;
   }
   else
   {
-    logMessage(LOU_LOG_DEBUG, "Node %s has no nodeEntry", (const char *)node->name);
     return no;
   }
 }

--- a/liblouisutdml/transcribe_document.c
+++ b/liblouisutdml/transcribe_document.c
@@ -39,7 +39,6 @@ transcribe_document (xmlNode * node)
   StyleType *style;
   xmlNode *child;
   int childrenDone = 0;
-  logMessage(LOU_LOG_DEBUG, "Begin transcribe_document");
   ud->top = -1;
   ud->style_top = -1;
   ud->text_length = 0;
@@ -144,6 +143,5 @@ transcribe_document (xmlNode * node)
     end_style ();
   end_document ();
   pop_sem_stack ();
-  logMessage(LOU_LOG_DEBUG, "Finished transcribe_document");
   return 1;
 }

--- a/liblouisutdml/transcribe_math.c
+++ b/liblouisutdml/transcribe_math.c
@@ -44,12 +44,10 @@ transcribe_math (xmlNode * node, int action)
   StyleType *style;
   xmlNode *child;
   int branchCount = 0;
-  logMessage(LOU_LOG_INFO, "Begin transcribe_math");
   if (node == NULL)
     return 0;
   if (action == 0)
     {
-      logMessage(LOU_LOG_DEBUG, "Math node action==0");
       insert_translation (ud->main_braille_table);
       curLink = node;
       if (ud->format_for == utd)
@@ -59,17 +57,14 @@ transcribe_math (xmlNode * node, int action)
     }
   else
     {
-      logMessage(LOU_LOG_DEBUG, "Math node action!=0");
       push_sem_stack (node);
     }
   switch (ud->stack[ud->top])
     {
     case skip:
-      logMessage(LOU_LOG_DEBUG, "Math node skip");
       pop_sem_stack ();
       return 1;
     case reverse:
-      logMessage(LOU_LOG_DEBUG, "Math node reverse");
       do_reverse (node);
       break;
     default:
@@ -77,7 +72,6 @@ transcribe_math (xmlNode * node, int action)
     }
   if ((style = is_style (node)) != NULL)
     {
-      logMessage(LOU_LOG_DEBUG, "Math node start style");
       mathTrans ();
       start_style (style, node);
     }
@@ -106,14 +100,12 @@ transcribe_math (xmlNode * node, int action)
   insert_code (node, -1);
   if (style)
     {
-      logMessage(LOU_LOG_DEBUG, "Math node end style");
       mathTrans ();
       end_style ();
     }
   pop_sem_stack ();
   if (action == 0)
     mathTrans ();
-  logMessage(LOU_LOG_INFO, "Finish transcribe_math");
   return 1;
 }
 

--- a/liblouisutdml/transcribe_paragraph.c
+++ b/liblouisutdml/transcribe_paragraph.c
@@ -198,7 +198,6 @@ transcribe_paragraph (xmlNode * node, int action)
   xmlNode *child;
   int branchCount = 0;
   int i;
-  logMessage(LOU_LOG_DEBUG, "Begin transcribe_paragraph");
   if (node == NULL)
     return 0;
   if (ud->top == 0)
@@ -338,7 +337,6 @@ transcribe_paragraph (xmlNode * node, int action)
   if (is_macro (node))
     {
       haveMacro = 1;
-      logMessage(LOU_LOG_DEBUG, "Node has macro");
       start_macro (node);
     }
   else if ((style = is_style (node)) != NULL)
@@ -349,7 +347,6 @@ transcribe_paragraph (xmlNode * node, int action)
 	    pop_sem_stack ();
 	  return 0;
 	}
-      logMessage(LOU_LOG_DEBUG, "Node has style");
       start_style (style, node);
     }
   child = node->children;
@@ -629,6 +626,5 @@ transcribe_paragraph (xmlNode * node, int action)
       insert_translation (ud->main_braille_table);
       write_paragraph (para, NULL);
     }
-  logMessage(LOU_LOG_DEBUG, "Finished transcribe_paragraph");
   return 1;
 }

--- a/liblouisutdml/transcriber.c
+++ b/liblouisutdml/transcriber.c
@@ -498,7 +498,7 @@ wc_string_to_utf8 (const widechar * inStr, int *inSize, unsigned char *outstr,
 	    {
 	      *inSize = in;
 	      *outSize = out;
-              logMessage(LOU_LOG_DEBUG, "Finish wc_string_to_utf8 due to not enough memory in outstr");
+              logMessage(LOU_LOG_FATAL, "Not enough memory in outstr");
 	      return 1;
 	    }
 	}

--- a/liblouisutdml/utd2brf.c
+++ b/liblouisutdml/utd2brf.c
@@ -83,7 +83,6 @@ brf_findBrlNodes (xmlNode * node)
     case utdmeta:
       return 1;
     case utdbrl:
-      logMessage(LOU_LOG_DEBUG, "Processing brl node");
       brf_doBrlNode (node, 0);
       pop_sem_stack ();
       return 1;
@@ -125,18 +124,14 @@ brf_insertCharacters (const char *text, int length)
 static int
 brf_doDotsText (xmlNode * node)
 {
-  logMessage(LOU_LOG_DEBUG, "brf_doDotsText %s", node->content);
   ud->text_length = 0;
   insert_utf8 (node->content);
   if ((ud->outbuf1_len_so_far + ud->text_length) > ud->outbuf1_len)
     brf_saveBuffer ();
-  logMessage(LOU_LOG_DEBUG, "text_buffer: %s", ud->text_buffer);
   if (!lou_dotsToChar (ud->main_braille_table, ud->text_buffer,
 		       &ud->outbuf1[ud->outbuf1_len_so_far],
 		       ud->text_length, 0))
     return 0;
-  logMessage(LOU_LOG_DEBUG, "ud->textLength %d", ud->text_length);
-  logMessage(LOU_LOG_DEBUG, "ud->outbuf1: %s", &ud->outbuf1[ud->outbuf1_len_so_far+1]);
   ud->outbuf1_len_so_far += ud->text_length;
   return 1;
 }


### PR DESCRIPTION
They add no value and make the code harder to read. Also if no log file is configured they also make the output of `file2brl` really hard to read.

If you need that sort of tracing learn how to use a debugger.