### PR TITLE
Set the default log level to WARN

### DIFF
--- a/liblouisutdml/logging.c
+++ b/liblouisutdml/logging.c
@@ -40,7 +40,7 @@ void EXPORT_CALL lbu_registerLogCallback(logcallback callback)
     logCallbackFunction = callback;
 }
 
-static logLevels logLevel = LOU_LOG_INFO;
+static logLevels logLevel = LOU_LOG_WARN;
 void EXPORT_CALL lbu_setLogLevel(logLevels level)
 {
   logLevel = level;

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -70,7 +70,7 @@ run_test () {
     # that file, so we need to start file2brl from there to make the
     # relative paths work
     (cd $(dirname $ini_file);
-     file2brl -w $tmp_dir -f $styles $input $tmp_dir/output.txt 2> /dev/null)
+     file2brl -w $tmp_dir -f $styles $input $tmp_dir/output.txt)
     if [ $? -ne 0 ]; then
 	cleanup_and_exit 99 "Invocation of file2brl failed with error code $?"
     else

--- a/tools/file2brl.c
+++ b/tools/file2brl.c
@@ -115,8 +115,8 @@ main (int argc, char **argv)
   UserData *ud;
 
   int optc;
-  lbu_setLogLevel(LOU_LOG_DEBUG);
-  lou_setLogLevel(LOU_LOG_DEBUG);
+  lbu_setLogLevel(LOU_LOG_WARN);
+  lou_setLogLevel(LOU_LOG_WARN);
   set_program_name (argv[0]);
   logFileName[0] = 0;
   


### PR DESCRIPTION
This reduces the amount of logging output that `file2brl` generates. 

This PR replaces #52