### PR TITLE
Update Docker files to latest 3.24 Liblouis version

### DIFF
--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -29,7 +29,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.21.0
+ARG LIBLOUIS_VERSION=3.24.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.21.0
+ARG LIBLOUIS_VERSION=3.24.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \


### PR DESCRIPTION
Hi Chris or any maintainer,

Hopefully this change rans correctly with online build workflows.
If yes, please apply the Liblouisutdml master branch this simple commit, and if this is possible, generate a new stable Liblouisutdml 3.12.0 version with based Liblouis latest 3.24.0 release for 64 bit Windows operating systems and 32 bit Windows operating systems.
Linux related binary build is not a problem, because if present a new stable source code version, distro maintainers will doing Linux related packages.

My committed change not do a drastical change, only updated with DOCKERfile.win32 and DOCKERFILE.win64 the Liblouis version from 3.21.0 version to latest 3.24.0 version.

Why very need this change (only my openion)?
Since Liblouisutdml version 3.11.0 are released ( in 2022. March 0), Liblouis stepped up three versions (3.22.0, 3.23.0, 3.24.0 versions).
Lot of Braille table changes are happened, new Braille tables are awailable with newest previous not implemented languages, or changed an already supported Braille standard (for example Danish braille), the swedish tables are full refactored to latest standard into 3.23.0 release, etc.

I not see scheduled new Liblouisutdml version publication date and new 3.12.0 milestone. I think in April Samuel doed importanter code related fixups since 3.11.0 version are released.

I suggest a think with future:
If the three month release date period for Liblouis UTDML is difficult to Liblouisutdml and Liblouis always sinchronized, we perhaps schedule Liblouisutdml new release with two Liblouis version release date, two release/year.
For example, 3.11.0 release publicated march 08, next release are perhaps easy publicating december if not have any regression errors the build and test generation.

I doed a small offline test, but I don't no right doing the test or not:
1. I ran make distwin command, my system I get right from Docker the Liblouisutdml 3.11.0 32 bit and 64 bit versions.
2. I unzip the 32 bit build.
3. I exported following variable, because I have only possibility into Wine looks the build:
```
export LOUIS_TABLEPATH=z:\\home\\hammera\\liblouisutdml\\share\\liblouis\\tables
```
4. I ran wine bin/file2brl.exe --version command.
I get following error messages my terminal:
„0009:err:module:import_dll Library libgcc_s_dw2-1.dll (which is needed by L"Z:\\home\\hammera\\liblouisutdml\\bin\\libxml2-2.dll") not found
0009:err:module:import_dll Library libxml2-2.dll (which is needed by L"Z:\\home\\hammera\\liblouisutdml\\bin\\liblouisutdml.dll") not found
0009:err:module:import_dll Library libgcc_s_dw2-1.dll (which is needed by L"Z:\\home\\hammera\\liblouisutdml\\bin\\liblouisutdml.dll") not found
0009:err:module:import_dll Library liblouisutdml.dll (which is needed by L"Z:\\home\\hammera\\liblouisutdml\\bin\\file2brl.exe") not found
0009:err:module:LdrInitializeThunk Importing dlls for L"Z:\\home\\hammera\\liblouisutdml\\bin\\file2brl.exe" failed, status c0000135”
This dll I think not prepackaged the build or not linked statically, I not have C experience. So if I use wrong terminology, very sorry. I usual programming with Python3.

I looked same method the 64 bit build, the 64 build works fine.
I ran wine bin/file2brl.exe --version command, and get following proper result:
„ERROR: ld.so: object 'libgtk3-nocsd.so.0' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
ERROR: ld.so: object 'libgtk3-nocsd.so.0' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
Z:\home\hammera\liblouisutdml\bin\file2brl.exe (liblouisutdml) 2.11.0
Copyright (C) 2013 ViewPlus Technologies, Inc. and JJB Software, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by John J. Boyer.”

The gtk3 related issue I think is not important for 64 bit build version.
I connverted right a html file to hungarian braille without no problem for 64 bit builded version.

Thanks,

Attila