### PR TITLE
Update Liblouis version both Dockerfile.win32, Dockerfile.win64, and Github action file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.24.0
+  LIBLOUIS_VERSION: 3.25.0
 
 jobs:
   build:

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -29,7 +29,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.24.0
+ARG LIBLOUIS_VERSION=3.25.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \
@@ -47,7 +47,7 @@ ADD https://raw.githubusercontent.com/liblouis/liblouis/master/libyaml_mingw.pat
 RUN patch -p1 <libyaml_mingw.patch
 RUN ./bootstrap && \
     ./configure --host ${HOST} --prefix=${PREFIX} && \
-    make && \
+    make LDFLAGS="-L${PREFIX}/lib/ -avoid-version -Xcompiler -static-libgcc" && \
     make install
 
 # Build and install libxml2
@@ -56,7 +56,7 @@ RUN curl -L ftp://xmlsoft.org/libxml2/libxml2-${LIBXML2_VERSION}.tar.gz | tar zx
 WORKDIR ${SRCDIR}/libxml2-${LIBXML2_VERSION}
 RUN autoreconf -i && \
     ./configure --with-zlib=no --with-iconv=no --with-python=no --with-threads=no --host ${HOST} --prefix=${PREFIX} && \
-    make && \
+    make LDFLAGS="-L${PREFIX}/lib/ -avoid-version -Xcompiler -static-libgcc" && \
     make install
 
 # Build and install liblouis
@@ -76,7 +76,7 @@ ADD . ${SRCDIR}/liblouisutdml
 WORKDIR ${SRCDIR}/liblouisutdml
 RUN ./autogen.sh && \
     ./configure  --host ${HOST} --disable-java-bindings --prefix=${PREFIX} && \
-    make && \
+    make LDFLAGS="-L${PREFIX}/lib/ -avoid-version -Xcompiler -static-libgcc" && \
     make install && \
     cd ${PREFIX} && \
     zip -r ${SRCDIR}/liblouisutdml/liblouisutdml.zip *

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.24.0
+ARG LIBLOUIS_VERSION=3.25.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \


### PR DESCRIPTION
Hi Chris,

I updated Liblouis version both Dockerfile.win32, Dockerfile.win64, and Github CI to the 3.25.0 stable version.

I added 32 bit Dockerfile.win32 file the static compile flags with all gcc compile commands (only Liblouis compile part contains this flag the original version).

My experience when I maked my local machine the make distwin command this changed Docker file, my machine 32 bit build version launched proper into Wine emulator.

So, my experience this change fixes #86 issue.

Please review this change if you have a little time. If your openion the static flags change not full perfect or unneed, feel free remove, only keep the version number change.

Attila