### PR TITLE
Update Liblouis version with 3.26 version the important build files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.25.0
+  LIBLOUIS_VERSION: 3.26.0
 
 jobs:
   build:

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -29,7 +29,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.25.0
+ARG LIBLOUIS_VERSION=3.26.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.25.0
+ARG LIBLOUIS_VERSION=3.26.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \


### PR DESCRIPTION
Hi Chris,

As it is usual, I updated the Liblouis stable version from 3.25.0 to 3.26.0 version into Dockerfile.win32, Dockerfile.win64 and .github/workflow/main.yml file.

The patch not too long, few lines only. If you have a little time, please review this patch and approve this change into the Liblouis UTDML master branch.

The Liblouis version update is need for Liblouis UTDML, because Liblouis 3.26 release contains larger improvements with Braille-tables related, for example hungarian, nemeth Braille tables.

After the update is happen, because not have other opened issues perhaps need do a new Liblouis UTDML release, because I thing Liblouis UTDML previous 2.11.0 release uses Liblouis 3.20.0 and publicated in 2022. march 8.

The make distwin command ran my machine succesfull.

congratulate the new Liblouis 3.26 release!
Kind regards,

Attila