### PR TITLE
Update Liblouis stable version from 3.26.0 to 3.27.0 version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.26.0
+  LIBLOUIS_VERSION: 3.27.0
 
 jobs:
   build:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -12,7 +12,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.26.0
+  LIBLOUIS_VERSION: 3.27.0
 
 jobs:
   sanitizer:

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -29,7 +29,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.26.0
+ARG LIBLOUIS_VERSION=3.27.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.26.0
+ARG LIBLOUIS_VERSION=3.27.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \

--- a/lbu_files/wiskunde.ctb
+++ b/lbu_files/wiskunde.ctb
@@ -40,16 +40,16 @@ midnum . 3
 repeated \x0020 0
 repeated \x00A0 a
 
-class  uppergreek          \x0391\x0392\x0393\x0394\x0395\x0396\x0397\x0398\x0399\x039A\x039B\x039C\x039D\x039E\x039F\x03A0\x03A1\x03A3\x03A4\x03A5\x03A6\x03A7\x03A8\x03A9
-class  lowergreek          \x03B1\x03B2\x03B3\x03B4\x03B5\x03B6\x03B7\x03B8\x03B9\x03BA\x03BB\x03BC\x03BD\x03BE\x03BF\x03C0\x03C1\x03C2\x03C3\x03C4\x03C5\x03C6\x03C7\x03C8\x03C9\x03D5
-class  operationkeyspace   \x002B\x002D\x002E\x003D\x007E\x00B1\x00D7\x00F7\x2190\x2191\x2192\x2193\x2194\x21D0\x21D2\x21D4\x2209\x220C\x2212\x2217\x2223\x2224\x2226\x2243\x2248\x2260\x2261\x2284\x2285\x2288\x2289\x22C5
-class  operationkey        \x002F\x003C\x2215\x2216\x2225\x2227\x2228\x2229\x222A\x2264\x2282\x2283\x2286\x2287\x22A5\x22D5
-class  operationnokey      \x003E\x00AF\x0302\x0303\x0304\x2191\x2193\x2208\x220B\x2265
+attribute  uppergreek          \x0391\x0392\x0393\x0394\x0395\x0396\x0397\x0398\x0399\x039A\x039B\x039C\x039D\x039E\x039F\x03A0\x03A1\x03A3\x03A4\x03A5\x03A6\x03A7\x03A8\x03A9
+attribute  lowergreek          \x03B1\x03B2\x03B3\x03B4\x03B5\x03B6\x03B7\x03B8\x03B9\x03BA\x03BB\x03BC\x03BD\x03BE\x03BF\x03C0\x03C1\x03C2\x03C3\x03C4\x03C5\x03C6\x03C7\x03C8\x03C9\x03D5
+attribute  operationkeyspace   \x002B\x002D\x002E\x003D\x007E\x00B1\x00D7\x00F7\x2190\x2191\x2192\x2193\x2194\x21D0\x21D2\x21D4\x2209\x220C\x2212\x2217\x2223\x2224\x2226\x2243\x2248\x2260\x2261\x2284\x2285\x2288\x2289\x22C5
+attribute  operationkey        \x002F\x003C\x2215\x2216\x2225\x2227\x2228\x2229\x222A\x2264\x2282\x2283\x2286\x2287\x22A5\x22D5
+attribute  operationnokey      \x003E\x00AF\x0302\x0303\x0304\x2191\x2193\x2208\x220B\x2265
 # class relation
-class  digitletter         abcdefghij
-swapcd dropped             0123456789                           356,2,23,25,256,26,235,2356,236,35
-swapdd upnum               245,1,12,14,145,15,124,1245,125,24   0,0,0,0,0,0,0,0,0,0
-swapdd lownum              356,2,23,25,256,26,235,2356,236,35   0,0,0,0,0,0,0,0,0,0
+attribute  digitletter         abcdefghij
+swapcd dropped             0123456789                                     356,2,23,25,256,26,235,2356,236,35
+swapdd upnum               2459,19,129,149,1459,159,1249,12459,1259,249   0,0,0,0,0,0,0,0,0,0
+swapdd lownum              356,2,23,25,256,26,235,2356,236,35             0,0,0,0,0,0,0,0,0,0
 
 exactdots @0
 exactdots @123456
@@ -148,9 +148,9 @@ exactdots @56
   noback pass3    @1b-24-1b-34-1235                        @34         # \ei\e⠌r
   noback pass3    @1b-24-1b-34-14                          @456@34     # \ei\e⠌c
   noback pass3    @1b-24-1b-34-123                         @3456@34    # \ei\e⠌l
-  noback pass3    @1b-24-1b-456-1235                       @16         # \ei\e_r
-  noback pass3    @1b-24-1b-456-14                         @456@16     # \ei\e_c
-  noback pass3    @1b-24-1b-456-123                        @3456@16    # \ei\e_l  
+  noback pass3    @1b-24-1b-4569-1235                      @16         # \ei\e_r
+  noback pass3    @1b-24-1b-4569-14                        @4569@16    # \ei\e_c
+  noback pass3    @1b-24-1b-4569-123                       @3456@16    # \ei\e_l
   noback pass3    @1b-24                                   ?           # \ei
   noback pass3    @1b-34-1235                              @4          # \e⠌r
   noback pass3    @1b-34-14                                @45         # \e⠌c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -494,21 +494,16 @@ XFAIL_TESTS +=					\
 	mathml_nemeth/mover_13.test		\
 	mathml_nemeth/mover_14.test		\
 	mathml_nemeth/mover_15.test		\
-	mathml_nemeth/mover_16.test		\
-	mathml_nemeth/munder_01.test		\
 	mathml_nemeth/munder_02.test		\
 	mathml_nemeth/munder_03.test		\
-	mathml_nemeth/munder_05.test		\
 	mathml_nemeth/munder_06.test		\
 	mathml_nemeth/munder_07.test		\
-	mathml_nemeth/munderover_01.test	\
 	mathml_nemeth/munderover_02.test	\
 	mathml_nemeth/munderover_03.test	\
 	nemeth_MathCAT/above_and_below_88_2.test			\
 	nemeth_MathCAT/arrow_96_4.test					\
 	nemeth_MathCAT/as_multiscript_nested_sub_sup_74_c_5.test	\
 	nemeth_MathCAT/bar_97_b_1.test					\
-	nemeth_MathCAT/bar_above_and_below_88_1.test			\
 	nemeth_MathCAT/beveled_frac_62_b_1.test				\
 	nemeth_MathCAT/binomial_90_1.test				\
 	nemeth_MathCAT/boldface_32_b_3.test				\
@@ -563,7 +558,6 @@ XFAIL_TESTS +=					\
 	nemeth_MathCAT/menclose_86_b_1.test				\
 	nemeth_MathCAT/menclose_86_b_11.test				\
 	nemeth_MathCAT/menclose_bar_97_b_1.test				\
-	nemeth_MathCAT/menclose_bar_97_b_3.test				\
 	nemeth_MathCAT/menclose_lesson_12_5_5_5.test			\
 	nemeth_MathCAT/menclose_primed_86_b_6.test			\
 	nemeth_MathCAT/menclose_top_bottom_88_1.test			\
@@ -655,7 +649,6 @@ XFAIL_TESTS +=					\
 	nemeth_MathCAT/vertical_bar_145_4.test				\
 	nemeth_MathCAT/whitespace_in_sup_79_e_1.test			\
 	nemeth_MathCAT/word_77_4_12.test				\
-	test_mathml_woluwe/test_044.test	\
 	test_mathml_woluwe/test_060.test	\
 	test_mathml_woluwe/test_061.test	\
 	test_mathml_woluwe/test_062.test	\

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -173,7 +173,6 @@ dist_suite_TESTS =				\
 	nemeth_MathCAT/function_space_119_c_3.test			\
 	nemeth_MathCAT/german_base_77_4_3.test			\
 	nemeth_MathCAT/hyper_complex_frac_68_a_1.test			\
-	nemeth_MathCAT/identity_matrix_126.test			\
 	nemeth_MathCAT/integral_77_4_26.test			\
 	nemeth_MathCAT/left_sup_75_12.test			\
 	nemeth_MathCAT/left_sup_75_1.test			\
@@ -295,7 +294,6 @@ dist_suite_TESTS =				\
 	nemeth_MathCAT/sub_sup_82_b_2.test			\
 	nemeth_MathCAT/sum_77_4_23.test			\
 	nemeth_MathCAT/superscript_80_a_2.test			\
-	nemeth_MathCAT/table_entry_after_sup_79_c_4.test			\
 	nemeth_MathCAT/tensor_from_mathml_spec.test			\
 	nemeth_MathCAT/test_9_d_2.test			\
 	nemeth_MathCAT/test_9_d_3.test			\
@@ -533,7 +531,6 @@ XFAIL_TESTS +=					\
 	nemeth_MathCAT/function_space_119_c_3.test			\
 	nemeth_MathCAT/german_base_77_4_3.test				\
 	nemeth_MathCAT/hyper_complex_frac_68_a_1.test			\
-	nemeth_MathCAT/identity_matrix_126.test				\
 	nemeth_MathCAT/integral_77_4_26.test				\
 	nemeth_MathCAT/left_sup_75_1.test				\
 	nemeth_MathCAT/left_sup_75_12.test				\
@@ -639,7 +636,6 @@ XFAIL_TESTS +=					\
 	nemeth_MathCAT/sub_ind_mmultiscripts_80_b_3.test		\
 	nemeth_MathCAT/sum_77_4_23.test					\
 	nemeth_MathCAT/superscript_80_a_2.test				\
-	nemeth_MathCAT/table_entry_after_sup_79_c_4.test		\
 	nemeth_MathCAT/tensor_from_mathml_spec.test			\
 	nemeth_MathCAT/test_9_d_2.test					\
 	nemeth_MathCAT/test_9_d_3.test					\

--- a/tests/test_mathml_woluwe/liblouisutdml.ini
+++ b/tests/test_mathml_woluwe/liblouisutdml.ini
@@ -24,7 +24,7 @@ xmlheader "<?xml version='1.0' encoding='UTF8' standalone='yes'?>"
 internetAccess no
 newEntries no
 semanticFiles ../../lbu_files/wiskunde.sem
-literarytextTable unicode.dis,../../lbu_files/wiskunde.ctb,braille-patterns.cti
-mathtextTable     unicode.dis,../../lbu_files/wiskunde.ctb,braille-patterns.cti
-mathexprTable     unicode.dis,../../lbu_files/wiskunde.ctb,braille-patterns.cti
+literarytextTable nl-unicode.dis,../../lbu_files/wiskunde.ctb,braille-patterns.cti
+mathtextTable     nl-unicode.dis,../../lbu_files/wiskunde.ctb,braille-patterns.cti
+mathexprTable     nl-unicode.dis,../../lbu_files/wiskunde.ctb,braille-patterns.cti
 editTable en-us-brf.dis,braille-patterns.cti,../../lbu_files/wiskunde_edit.ctb


### PR DESCRIPTION
Hi Boys,

As it is usual, I updated after Liblouis 3.27.0 release publication the Liblouis UTDML used stable version from 3.26.0 version to 3.27.0 version.
The first commit affected  files:
* Dockerfile.win32,
* Dockerfile.win64,
* .github/workflows/main.yml,
* .github/workflows/sanitizer.yml

The second commit resolves 25 failed voluve test files failures related issue after 3.27.0 version migration, the diff output is showed @bertfrees in Liblouis issue [#1434](https://github.com/liblouis/liblouis/issues/1434).
The second commit fixes [Liblouis issue #1434](https://github.com/liblouis/liblouis/issues/1434)

My machine make distwin command ran succesfull.

Attila