### PR TITLE
Increase Liblouis version number to 3.28.0 version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.27.0
+  LIBLOUIS_VERSION: 3.28.0
 
 jobs:
   build:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -12,7 +12,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.27.0
+  LIBLOUIS_VERSION: 3.28.0
 
 jobs:
   sanitizer:

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -29,7 +29,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.27.0
+ARG LIBLOUIS_VERSION=3.28.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.27.0
+ARG LIBLOUIS_VERSION=3.28.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -604,9 +604,14 @@ XFAIL_TESTS +=					\
 	test_mathml_woluwe/test_075.test	\
 	test_mathml_woluwe/test_076.test	\
 	test_mathml_woluwe/test_078.test	\
+	test_mathml_woluwe/test_080.test	\
 	test_mathml_woluwe/test_093.test	\
 	test_mathml_woluwe/test_096.test	\
-	test_mathml_woluwe/test_099.test
+	test_mathml_woluwe/test_099.test	\
+	test_mathml_woluwe/test_106.test	\
+	test_mathml_woluwe/test_107.test	\
+	test_mathml_woluwe/test_113.test	\
+	test_mathml_woluwe/test_114.test
 
 TESTS =						\
 	$(check_PROGRAMS)			\


### PR DESCRIPTION
Hi Boys,

As it is usual after new Liblouis stable release publication, I updated into Liblouisutdml source tree the proper files to synchronise the version number the new version (now with increasing Liblouis version number from 3.27.0 to 3.28.0 version number).
If this is possible, please approve and merget this little changes the master branch.
Affected files:
* Dockerfile.win32,
* Dockerfile.win64,
* .github/workflows/main.yml,
* .github/workflows/sanitizer.yml.
If future the community would like publicating a new Liblouisutdml release (after 2024. march or 2024. june for example), better to syncing the Liblouis version number the actual stable release.
Note: anybody not known an automatic possibility, similar with dependabot handles the required dependency versions in Liblouis to always inclease Liblouis version number when releasing a new Liblouis stable version (for example in 2024. march, 2024. june, 2024. september and 2024. december)? :-):-)
Roughly, an automatic Github operation file would be good, which always increases the version number of Liblouis in the four source files to the version number of the current Liblouis stable release the day after the publication of the current Liblouis release, and then automatically submits a pull request as, e.g. at Liblouis, dependabot does this when different component version numbers change (golang version number, scorecard version number change, etc.). :-):-)

If the last part related my english is not full good, sorry, hopefully you understanding what can I would like suggesting.

Attila