### PR TITLE
Hi guys,  When Norbert and I worked on the modifications to the Nemeth boards, I filled in the standard data related to the modification (name, e-mail address in a distorted form, and the year of the modification when the change was made) according to the usual standard for most of the boards. Where norbert created a completely new table, I used the Copyright style text, where expansion or modification took place, where I used the expanded and modified by type text, and inserted Norbert's name and email address in distorted form. Unfortunately, this data was not filled in for the lbu_files/nemeth_edit.ctb table, when Norbert sent a completely new version after the first revision, I forgot filling the proper modification related information line the table before the 13TH line, accidentally uploaded the change to our development branch without the necessary information. The other tables are fine, I fixed this one line only in the nemeth_edit.ctb file.  Attila

### DIFF
--- a/lbu_files/nemeth_edit.ctb
+++ b/lbu_files/nemeth_edit.ctb
@@ -10,6 +10,7 @@
 #
 #  Copyright (C) 2004-2006 ViewPlus Technologies, Inc. www.viewplus.com
 #  Copyright (C) 2004-2006 JJB Software, Inc. www.jjb-software.com
+#  Expanded and modified by Norbert Márkus (hamilfonz at gmail dot com), Hungary, 2023.
 #
 #  This file is part of liblouis.
 #


### PR DESCRIPTION
Hi guys,

When Norbert and I worked on the modifications to the Nemeth boards, I filled in the standard data related to the modification (name, e-mail address in a distorted form, and the year of the modification when the change was made) according to the usual standard for most of the boards.
Where norbert created a completely new table, I used the Copyright style text, where expansion or modification took place, where I used the expanded and modified by type text, and inserted Norbert's name and email address in distorted form.
Unfortunately, this data was not filled in for the lbu_files/nemeth_edit.ctb table, when Norbert sent a completely new version after the first revision, I forgot filling the proper modification related information line the table before the 13TH line, accidentally uploaded the change to our development branch without the necessary information.
The other tables are fine, I fixed this one line only in the nemeth_edit.ctb file.

Attila