### PR TITLE
fix -Wimplicit-function-declaration warnings

### DIFF
--- a/liblouisutdml/liblouisutdml.c
+++ b/liblouisutdml/liblouisutdml.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "louisutdml.h"
+#include <libxml/xmlsave.h>
 #include <libxml/HTMLparser.h>
 #include <libxml/catalog.h>
 

--- a/liblouisutdml/transcriber.c
+++ b/liblouisutdml/transcriber.c
@@ -32,6 +32,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libxml/parser.h>
+#include <libxml/xmlsave.h>
 #include "louisutdml.h"
 
 static xmlNode *firstBrlNode;

--- a/liblouisutdml/utd2brf.c
+++ b/liblouisutdml/utd2brf.c
@@ -30,6 +30,7 @@
    */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "louisutdml.h"
 

--- a/liblouisutdml/utd2dsbible.c
+++ b/liblouisutdml/utd2dsbible.c
@@ -30,6 +30,7 @@
    */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "louisutdml.h"
 

--- a/liblouisutdml/utd2pef.c
+++ b/liblouisutdml/utd2pef.c
@@ -30,6 +30,7 @@
    */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "louisutdml.h"
 

--- a/liblouisutdml/utd2transinxml.c
+++ b/liblouisutdml/utd2transinxml.c
@@ -30,6 +30,7 @@
    */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "louisutdml.h"
 

--- a/liblouisutdml/utd2volumes.c
+++ b/liblouisutdml/utd2volumes.c
@@ -30,6 +30,7 @@
    */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "louisutdml.h"
 


### PR DESCRIPTION
Fix building with latest libxml2 2.12.x and gcc 14.x `-Wimplicit-function-declaration` warning.

<details>
<summary>Without those fixes build fails with
</summary>

```console

make[2]: Entering directory '/home/tkloczko/rpmbuild/BUILD/liblouisutdml-2.12.0/liblouisutdml'
/bin/sh ../libtool  --tag=CC   --mode=compile /usr/bin/gcc -DHAVE_CONFIG_H -I.  -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB  -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c -o liblouisutdml_la-liblouisutdml.lo `test -f 'liblouisutdml.c' || echo './'`liblouisutdml.c
libtool: compile:  /usr/bin/gcc -DHAVE_CONFIG_H -I. -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c liblouisutdml.c  -fPIC -DPIC -o .libs/liblouisutdml_la-liblouisutdml.o
liblouisutdml.c: In function 'cleanupLibxml':
liblouisutdml.c:81:3: warning: 'initGenericErrorDefaultFunc' is deprecated [-Wdeprecated-declarations]
   81 |   initGenericErrorDefaultFunc (NULL);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/libxml2/libxml/valid.h:15,
                 from /usr/include/libxml2/libxml/parser.h:19,
                 from louisutdml.h:34,
                 from liblouisutdml.c:36:
/usr/include/libxml2/libxml/xmlerror.h:894:5: note: declared here
  894 |     initGenericErrorDefaultFunc (xmlGenericErrorFunc *handler);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
liblouisutdml.c: In function 'processXmlDocument':
liblouisutdml.c:105:7: warning: 'xmlKeepBlanksDefault' is deprecated [-Wdeprecated-declarations]
  105 |       LIBXML_TEST_VERSION xmlKeepBlanksDefault (0);
      |       ^~~~~~~~~~~~~~~~~~~
/usr/include/libxml2/libxml/parser.h:957:17: note: declared here
  957 |                 xmlKeepBlanksDefault    (int val);
      |                 ^~~~~~~~~~~~~~~~~~~~
liblouisutdml.c:106:7: warning: 'xmlSubstituteEntitiesDefault' is deprecated [-Wdeprecated-declarations]
  106 |       xmlSubstituteEntitiesDefault (1);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libxml2/libxml/parser.h:953:17: note: declared here
  953 |                 xmlSubstituteEntitiesDefault(int val);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
liblouisutdml.c:107:7: error: implicit declaration of function 'xmlThrDefIndentTreeOutput'; did you mean 'xmlIndentTreeOutput'? [-Wimplicit-function-declaration]
  107 |       xmlThrDefIndentTreeOutput (1);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
      |       xmlIndentTreeOutput
liblouisutdml.c:108:7: warning: 'xmlThrDefKeepBlanksDefaultValue' is deprecated [-Wdeprecated-declarations]
  108 |       xmlThrDefKeepBlanksDefaultValue (0);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libxml2/libxml/parser.h:959:17: note: declared here
  959 |                 xmlThrDefKeepBlanksDefaultValue(int v);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
liblouisutdml.c:109:7: warning: 'xmlThrDefLineNumbersDefaultValue' is deprecated [-Wdeprecated-declarations]
  109 |       xmlThrDefLineNumbersDefaultValue (1);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libxml2/libxml/parser.h:969:17: note: declared here
  969 |                 xmlThrDefLineNumbersDefaultValue(int v);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
liblouisutdml.c:149:57: warning: pointer targets in passing argument 1 of 'ignore_case_comp' differ in signedness [-Wpointer-sign]
  149 |   if (ud->format_for >= utd && ignore_case_comp (ud->doc->encoding,
      |                                                  ~~~~~~~^~~~~~~~~~
      |                                                         |
      |                                                         const xmlChar * {aka const unsigned char *}
louisutdml.h:420:35: note: expected 'const char *' but argument is of type 'const xmlChar *' {aka 'const unsigned char *'}
  420 | int ignore_case_comp (const char *str1, const char *str2, int length);
      |                       ~~~~~~~~~~~~^~~~
make[2]: *** [Makefile:1225: liblouisutdml_la-liblouisutdml.lo] Error 1
/bin/sh ../libtool  --tag=CC   --mode=compile /usr/bin/gcc -DHAVE_CONFIG_H -I.  -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB  -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c -o liblouisutdml_la-utd2transinxml.lo `test -f 'utd2transinxml.c' || echo './'`utd2transinxml.c
libtool: compile:  /usr/bin/gcc -DHAVE_CONFIG_H -I. -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c utd2transinxml.c  -fPIC -DPIC -o .libs/liblouisutdml_la-utd2transinxml.o
utd2transinxml.c: In function 'doUtdnewline':
utd2transinxml.c:233:20: error: implicit declaration of function 'atoi' [-Wimplicit-function-declaration]
  233 |   leadingBlanks = (atoi (xy) - ud->left_margin) / ud->cell_width;
      |                    ^~~~
utd2transinxml.c:228:7: warning: variable 'linepos' set but not used [-Wunused-but-set-variable]
  228 |   int linepos;
      |       ^~~~~~~
utd2transinxml.c: In function 'finishBrlNode':
utd2transinxml.c:314:12: warning: variable 'linkedTransNode' set but not used [-Wunused-but-set-variable]
  314 |   xmlNode *linkedTransNode;
      |            ^~~~~~~~~~~~~~~
utd2transinxml.c: At top level:
utd2transinxml.c:44:12: warning: 'doUtddispimg' declared 'static' but never defined [-Wunused-function]
   44 | static int doUtddispimg (xmlNode * node);
      |            ^~~~~~~~~~~~
make[2]: *** [Makefile:1323: liblouisutdml_la-utd2transinxml.lo] Error 1
/bin/sh ../libtool  --tag=CC   --mode=compile /usr/bin/gcc -DHAVE_CONFIG_H -I.  -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB  -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c -o liblouisutdml_la-utd2dsbible.lo `test -f 'utd2dsbible.c' || echo './'`utd2dsbible.c
libtool: compile:  /usr/bin/gcc -DHAVE_CONFIG_H -I. -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c utd2dsbible.c  -fPIC -DPIC -o .libs/liblouisutdml_la-utd2dsbible.o
utd2dsbible.c: In function 'doUtdnewpage':
utd2dsbible.c:290:20: error: implicit declaration of function 'atoi' [-Wimplicit-function-declaration]
  290 |   prevBrlPageNum = atoi (xmlGetProp (node, (xmlChar *) "brlnumber"));
      |                    ^~~~
utd2dsbible.c: In function 'doUtdnewline':
utd2dsbible.c:300:7: warning: variable 'linepos' set but not used [-Wunused-but-set-variable]
  300 |   int linepos;
      |       ^~~~~~~
utd2dsbible.c: At top level:
utd2dsbible.c:150:1: warning: 'doUtddispimg' defined but not used [-Wunused-function]
  150 | doUtddispimg (xmlNode *node)
      | ^~~~~~~~~~~~
make[2]: *** [Makefile:1330: liblouisutdml_la-utd2dsbible.lo] Error 1
/bin/sh ../libtool  --tag=CC   --mode=compile /usr/bin/gcc -DHAVE_CONFIG_H -I.  -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB  -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c -o liblouisutdml_la-utd2brf.lo `test -f 'utd2brf.c' || echo './'`utd2brf.c
libtool: compile:  /usr/bin/gcc -DHAVE_CONFIG_H -I. -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c utd2brf.c  -fPIC -DPIC -o .libs/liblouisutdml_la-utd2brf.o
utd2brf.c: In function 'brf_doUtdnewline':
utd2brf.c:233:7: error: implicit declaration of function 'atoi' [-Wimplicit-function-declaration]
  233 |   k = atoi (xy);
      |       ^~~~
make[2]: *** [Makefile:1337: liblouisutdml_la-utd2brf.lo] Error 1
/bin/sh ../libtool  --tag=CC   --mode=compile /usr/bin/gcc -DHAVE_CONFIG_H -I.  -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB  -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c -o liblouisutdml_la-utd2pef.lo `test -f 'utd2pef.c' || echo './'`utd2pef.c
libtool: compile:  /usr/bin/gcc -DHAVE_CONFIG_H -I. -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c utd2pef.c  -fPIC -DPIC -o .libs/liblouisutdml_la-utd2pef.o
utd2pef.c: In function 'doUtdnewline':
utd2pef.c:160:20: error: implicit declaration of function 'atoi' [-Wimplicit-function-declaration]
  160 |   leadingBlanks = (atoi (&xy[k + 1]) - ud->left_margin) /
      |                    ^~~~
utd2pef.c: At top level:
utd2pef.c:112:1: warning: 'doDotsText' defined but not used [-Wunused-function]
  112 | doDotsText (xmlNode * node)
      | ^~~~~~~~~~
make[2]: *** [Makefile:1344: liblouisutdml_la-utd2pef.lo] Error 1
/bin/sh ../libtool  --tag=CC   --mode=compile /usr/bin/gcc -DHAVE_CONFIG_H -I.  -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB  -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c -o liblouisutdml_la-utd2volumes.lo `test -f 'utd2volumes.c' || echo './'`utd2volumes.c
libtool: compile:  /usr/bin/gcc -DHAVE_CONFIG_H -I. -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c utd2volumes.c  -fPIC -DPIC -o .libs/liblouisutdml_la-utd2volumes.o
utd2volumes.c: In function 'doUtdnewline':
utd2volumes.c:217:20: error: implicit declaration of function 'atoi' [-Wimplicit-function-declaration]
  217 |   leadingBlanks = (atoi (xy) - ud->left_margin) / ud->cell_width;
      |                    ^~~~
utd2volumes.c:212:7: warning: variable 'linepos' set but not used [-Wunused-but-set-variable]
  212 |   int linepos;
      |       ^~~~~~~
utd2volumes.c: At top level:
utd2volumes.c:44:12: warning: 'doUtddispimg' declared 'static' but never defined [-Wunused-function]
   44 | static int doUtddispimg (xmlNode * node);
      |            ^~~~~~~~~~~~
make[2]: *** [Makefile:1351: liblouisutdml_la-utd2volumes.lo] Error 1
/bin/sh ../libtool  --tag=CC   --mode=compile /usr/bin/gcc -DHAVE_CONFIG_H -I.  -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB  -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c -o liblouisutdml_la-transcriber.lo `test -f 'transcriber.c' || echo './'`transcriber.c
libtool: compile:  /usr/bin/gcc -DHAVE_CONFIG_H -I. -I.. -DLBU_PATH=\"/usr/share/liblouisutdml/lbu_files/\" -DLIBLOUIS_TABLES_PATH=\"/usr/share/liblouis/tables/\" -DLBULIB -I/usr/include/liblouis -I/usr/include/libxml2 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -O2 -g -grecord-gcc-switches -pipe -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -flto=auto -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -Wall -Werror=format-security -Os -c transcriber.c  -fPIC -DPIC -o .libs/liblouisutdml_la-transcriber.o
transcriber.c: In function 'start_document':
transcriber.c:205:37: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
  205 |   style = prevStyle = lookup_style ("document");
      |                                     ^~~~~~~~~~
      |                                     |
      |                                     char *
In file included from transcriber.c:35:
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c: In function 'transcribe_text_string':
transcriber.c:297:39: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
  297 |   StyleType *docStyle = lookup_style ("document");
      |                                       ^~~~~~~~~~
      |                                       |
      |                                       char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c:298:40: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
  298 |   StyleType *paraStyle = lookup_style ("para");
      |                                        ^~~~~~
      |                                        |
      |                                        char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c: In function 'transcribe_text_file':
transcriber.c:353:39: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
  353 |   StyleType *docStyle = lookup_style ("document");
      |                                       ^~~~~~~~~~
      |                                       |
      |                                       char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c:354:40: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
  354 |   StyleType *paraStyle = lookup_style ("para");
      |                                        ^~~~~~
      |                                        |
      |                                        char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c: In function 'insert_utf8':
transcriber.c:669:31: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
  669 |         style = lookup_style ("para");
      |                               ^~~~~~
      |                               |
      |                               char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c: In function 'handlePagenum':
transcriber.c:1024:23: warning: pointer targets in assignment from 'char *' to 'xmlChar *' {aka 'unsigned char *'} differ in signedness [-Wpointer-sign]
 1024 |       printPageNumber = autoPageNumber;
      |                       ^
transcriber.c:1027:30: warning: pointer targets in passing argument 1 of 'strtol' differ in signedness [-Wpointer-sign]
 1027 |     ud->page_number = strtol(printPageNumber, NULL, 10);
      |                              ^~~~~~~~~~~~~~~
      |                              |
      |                              xmlChar * {aka unsigned char *}
In file included from transcriber.c:33:
/usr/include/stdlib.h:177:48: note: expected 'const char * restrict' but argument is of type 'xmlChar *' {aka 'unsigned char *'}
  177 | extern long int strtol (const char *__restrict __nptr,
      |                         ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
transcriber.c:1031:18: warning: pointer targets in passing argument 2 of 'strcat' differ in signedness [-Wpointer-sign]
 1031 |   strcat (setup, printPageNumber);
      |                  ^~~~~~~~~~~~~~~
      |                  |
      |                  xmlChar * {aka unsigned char *}
In file included from /usr/include/features.h:503,
                 from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:28,
                 from transcriber.c:32:
/usr/include/bits/string_fortified.h:128:1: note: expected 'const char *' but argument is of type 'xmlChar *' {aka 'unsigned char *'}
  128 | __NTH (strcat (char *__restrict __dest, const char *__restrict __src))
      | ^~~~~
transcriber.c:1033:13: warning: pointer targets in passing argument 1 of 'utf8ToWc' differ in signedness [-Wpointer-sign]
 1033 |   utf8ToWc (setup, &length, &translationBuffer[0], &translationLength);
      |             ^~~~~
      |             |
      |             char *
transcriber.c:551:32: note: expected 'const unsigned char *' but argument is of type 'char *'
  551 | utf8ToWc (const unsigned char *utf8str, int *inSize, widechar *
      |           ~~~~~~~~~~~~~~~~~~~~~^~~~~~~
transcriber.c: In function 'do_pagebreak':
transcriber.c:1080:42: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
 1080 |     utd_pagebreak (node, number, strlen (number));
      |                                          ^~~~~~
      |                                          |
      |                                          xmlChar * {aka unsigned char *}
In file included from transcriber.c:34:
/usr/include/string.h:407:35: note: expected 'const char *' but argument is of type 'xmlChar *' {aka 'unsigned char *'}
  407 | extern size_t strlen (const char *__s)
      |                       ~~~~~~~~~~~~^~~
transcriber.c:1080:26: warning: pointer targets in passing argument 2 of 'utd_pagebreak' differ in signedness [-Wpointer-sign]
 1080 |     utd_pagebreak (node, number, strlen (number));
      |                          ^~~~~~
      |                          |
      |                          xmlChar * {aka unsigned char *}
transcriber.c:171:50: note: expected 'char *' but argument is of type 'xmlChar *' {aka 'unsigned char *'}
  171 | static void utd_pagebreak (xmlNode * node, char *printPageNumber, int length);
      |                                            ~~~~~~^~~~~~~~~~~~~~~
transcriber.c:1082:36: warning: pointer targets in passing argument 1 of 'strlen' differ in signedness [-Wpointer-sign]
 1082 |     handlePagenum (number, strlen (number));
      |                                    ^~~~~~
      |                                    |
      |                                    xmlChar * {aka unsigned char *}
/usr/include/string.h:407:35: note: expected 'const char *' but argument is of type 'xmlChar *' {aka 'unsigned char *'}
  407 | extern size_t strlen (const char *__s)
      |                       ~~~~~~~~~~~~^~~
transcriber.c: In function 'do_attrtotext':
transcriber.c:1089:22: warning: pointer targets in passing argument 2 of 'strcpy' differ in signedness [-Wpointer-sign]
 1089 |   strcpy (attrValue, get_attr_value (node));
      |                      ^~~~~~~~~~~~~~~~~~~~~
      |                      |
      |                      xmlChar * {aka unsigned char *}
/usr/include/bits/string_fortified.h:77:1: note: expected 'const char *' but argument is of type 'xmlChar *' {aka 'unsigned char *'}
   77 | __NTH (strcpy (char *__restrict __dest, const char *__restrict __src))
      | ^~~~~
transcriber.c:1096:29: warning: pointer targets in passing argument 2 of 'insert_text_string' differ in signedness [-Wpointer-sign]
 1096 |   insert_text_string (node, attrValue);
      |                             ^~~~~~~~~
      |                             |
      |                             char *
louisutdml.h:421:50: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  421 | void insert_text_string (xmlNode *node, xmlChar *str);
      |                                         ~~~~~~~~~^~~
transcriber.c: In function 'getBraillePageString':
transcriber.c:1268:3: warning: enumeration value 'normal' not handled in switch [-Wswitch]
 1268 |   switch (ud->cur_brl_page_num_format) {
      |   ^~~~~~
transcriber.c:1268:3: warning: enumeration value 'blank' not handled in switch [-Wswitch]
transcriber.c:1268:3: warning: enumeration value 'p' not handled in switch [-Wswitch]
transcriber.c: In function 'getPageNumber':
transcriber.c:1423:7: warning: unused variable 'k' [-Wunused-variable]
 1423 |   int k;
      |       ^
transcriber.c: In function 'addPagesToPrintPageNumber':
transcriber.c:1477:7: warning: unused variable 'k' [-Wunused-variable]
 1477 |   int k;
      |       ^
transcriber.c: In function 'continuePrintPageNumber':
transcriber.c:1599:7: warning: unused variable 'k' [-Wunused-variable]
 1599 |   int k;
      |       ^
transcriber.c: In function 'write_buffer':
transcriber.c:1902:7: warning: variable 'buffer_from_len' set but not used [-Wunused-but-set-variable]
 1902 |   int buffer_from_len;
      |       ^~~~~~~~~~~~~~~
transcriber.c: In function 'write_paragraph':
transcriber.c:3237:31: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
 3237 |     holdStyle = lookup_style ("para");
      |                               ^~~~~~
      |                               |
      |                               char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c: In function 'makeLinkOrTarget':
transcriber.c:3693:25: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
 3693 |   style = lookup_style ("para");
      |                         ^~~~~~
      |                         |
      |                         char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c: In function 'start_style':
transcriber.c:3865:30: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
 3865 |     curStyle = lookup_style ("para");
      |                              ^~~~~~
      |                              |
      |                              char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c:3867:31: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
 3867 |     prevStyle = lookup_style ("para");
      |                               ^~~~~~
      |                               |
      |                               char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c: In function 'makeDaisyDoc':
transcriber.c:4017:7: warning: 'xmlKeepBlanksDefault' is deprecated [-Wdeprecated-declarations]
 4017 |       LIBXML_TEST_VERSION xmlKeepBlanksDefault (0);
      |       ^~~~~~~~~~~~~~~~~~~
In file included from louisutdml.h:34:
/usr/include/libxml2/libxml/parser.h:957:17: note: declared here
  957 |                 xmlKeepBlanksDefault    (int val);
      |                 ^~~~~~~~~~~~~~~~~~~~
transcriber.c:4018:7: warning: 'xmlSubstituteEntitiesDefault' is deprecated [-Wdeprecated-declarations]
 4018 |       xmlSubstituteEntitiesDefault (1);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libxml2/libxml/parser.h:953:17: note: declared here
  953 |                 xmlSubstituteEntitiesDefault(int val);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
transcriber.c:4019:7: error: implicit declaration of function 'xmlThrDefIndentTreeOutput'; did you mean 'xmlIndentTreeOutput'? [-Wimplicit-function-declaration]
 4019 |       xmlThrDefIndentTreeOutput (1);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
      |       xmlIndentTreeOutput
transcriber.c:4020:7: warning: 'xmlThrDefKeepBlanksDefaultValue' is deprecated [-Wdeprecated-declarations]
 4020 |       xmlThrDefKeepBlanksDefaultValue (0);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libxml2/libxml/parser.h:959:17: note: declared here
  959 |                 xmlThrDefKeepBlanksDefaultValue(int v);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
transcriber.c:4021:7: warning: 'xmlThrDefLineNumbersDefaultValue' is deprecated [-Wdeprecated-declarations]
 4021 |       xmlThrDefLineNumbersDefaultValue (1);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libxml2/libxml/parser.h:969:17: note: declared here
  969 |                 xmlThrDefLineNumbersDefaultValue(int v);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
transcriber.c: In function 'processDaisyDoc':
transcriber.c:4063:3: warning: 'initGenericErrorDefaultFunc' is deprecated [-Wdeprecated-declarations]
 4063 |   initGenericErrorDefaultFunc (NULL);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/libxml2/libxml/valid.h:15,
                 from /usr/include/libxml2/libxml/parser.h:19:
/usr/include/libxml2/libxml/xmlerror.h:894:5: note: declared here
  894 |     initGenericErrorDefaultFunc (xmlGenericErrorFunc *handler);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
transcriber.c: In function 'freeDaisyDoc':
transcriber.c:4081:3: warning: 'initGenericErrorDefaultFunc' is deprecated [-Wdeprecated-declarations]
 4081 |   initGenericErrorDefaultFunc (NULL);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libxml2/libxml/xmlerror.h:894:5: note: declared here
  894 |     initGenericErrorDefaultFunc (xmlGenericErrorFunc *handler);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
transcriber.c: In function 'formatBackBlock':
transcriber.c:4362:7: warning: unused variable 'k' [-Wunused-variable]
 4362 |   int k;
      |       ^
transcriber.c: In function 'utd_back_translate_file':
transcriber.c:4380:7: warning: variable 'ppch' set but not used [-Wunused-but-set-variable]
 4380 |   int ppch = 0;
      |       ^~~~
transcriber.c: In function 'utd_back_translate_braille_string':
transcriber.c:4430:7: warning: variable 'ppch' set but not used [-Wunused-but-set-variable]
 4430 |   int ppch = 0;
      |       ^~~~
transcriber.c: In function 'utd_makePageSeparator':
transcriber.c:4724:25: warning: pointer targets in passing argument 2 of 'setOrigTextChar' differ in signedness [-Wpointer-sign]
 4724 |   setOrigTextChar (&sb, setup, length);
      |                         ^~~~~
      |                         |
      |                         char *
transcriber.c:4587:62: note: expected 'unsigned char *' but argument is of type 'char *'
 4587 | setOrigTextChar (ShortBrlOnlyStrings * sbstr, unsigned char *inStr, int
      |                                               ~~~~~~~~~~~~~~~^~~~~
transcriber.c: In function 'utd_getBraillePageString':
transcriber.c:4775:33: warning: pointer targets in passing argument 2 of 'setOrigTextChar' differ in signedness [-Wpointer-sign]
 4775 |   setOrigTextChar (&pageNumber, brlPageString, strlen (brlPageString));
      |                                 ^~~~~~~~~~~~~
      |                                 |
      |                                 char *
transcriber.c:4587:62: note: expected 'unsigned char *' but argument is of type 'char *'
 4587 | setOrigTextChar (ShortBrlOnlyStrings * sbstr, unsigned char *inStr, int
      |                                               ~~~~~~~~~~~~~~~^~~~~
transcriber.c: In function 'utd_getPageNumber':
transcriber.c:4798:7: warning: unused variable 'k' [-Wunused-variable]
 4798 |   int k;
      |       ^
transcriber.c: In function 'hasAttrValue':
transcriber.c:4871:19: warning: pointer targets in passing argument 2 of 'strcpy' differ in signedness [-Wpointer-sign]
 4871 |   strcpy (values, allValues);
      |                   ^~~~~~~~~
      |                   |
      |                   xmlChar * {aka unsigned char *}
/usr/include/bits/string_fortified.h:77:1: note: expected 'const char *' but argument is of type 'xmlChar *' {aka 'unsigned char *'}
   77 | __NTH (strcpy (char *__restrict __dest, const char *__restrict __src))
      | ^~~~~
transcriber.c: In function 'utd_finishLine':
transcriber.c:5217:7: warning: unused variable 'k' [-Wunused-variable]
 5217 |   int k;
      |       ^
transcriber.c: In function 'utd_doComputerCode':
transcriber.c:5426:7: warning: unused variable 'k' [-Wunused-variable]
 5426 |   int k;
      |       ^
transcriber.c: In function 'do_utdxxxximg':
transcriber.c:5819:10: warning: pointer targets in assignment from 'xmlChar *' {aka 'unsigned char *'} to 'char *' differ in signedness [-Wpointer-sign]
 5819 |   cwidth = xmlGetProp (node, (xmlChar *) "twidth");
      |          ^
transcriber.c:5820:11: warning: pointer targets in assignment from 'xmlChar *' {aka 'unsigned char *'} to 'char *' differ in signedness [-Wpointer-sign]
 5820 |   cheight = xmlGetProp (node, (xmlChar *) "twidth");
      |           ^
transcriber.c: In function 'utd_finish':
transcriber.c:5893:31: warning: pointer targets in passing argument 1 of 'lookup_style' differ in signedness [-Wpointer-sign]
 5893 |         style = lookup_style ("para");
      |                               ^~~~~~
      |                               |
      |                               char *
louisutdml.h:376:36: note: expected 'xmlChar *' {aka 'unsigned char *'} but argument is of type 'char *'
  376 | StyleType *lookup_style (xmlChar * name);
      |                          ~~~~~~~~~~^~~~
transcriber.c: At top level:
transcriber.c:999:1: warning: 'fillPageForce' defined but not used [-Wunused-function]
  999 | fillPageForce ()
      | ^~~~~~~~~~~~~
transcriber.c:279:1: warning: 'isLineend' defined but not used [-Wunused-function]
  279 | isLineend (int *c)
      | ^~~~~~~~~
make[2]: *** [Makefile:1358: liblouisutdml_la-transcriber.lo] Error 1
```
</details>