### PR TITLE
lbu_files/wiskunde.ctb: Replace dot 4569 to 456a (underscore simbol)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.29.0
+  LIBLOUIS_VERSION: 3.30.0
 
 jobs:
   build:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -12,7 +12,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.29.0
+  LIBLOUIS_VERSION: 3.30.0
 
 jobs:
   sanitizer:

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -29,7 +29,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.29.0
+ARG LIBLOUIS_VERSION=3.30.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.29.0
+ARG LIBLOUIS_VERSION=3.30.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \

--- a/lbu_files/wiskunde.ctb
+++ b/lbu_files/wiskunde.ctb
@@ -148,9 +148,9 @@ exactdots @56
   noback pass3    @1b-24-1b-34-1235                        @34         # \ei\e⠌r
   noback pass3    @1b-24-1b-34-14                          @456@34     # \ei\e⠌c
   noback pass3    @1b-24-1b-34-123                         @3456@34    # \ei\e⠌l
-  noback pass3    @1b-24-1b-4569-1235                      @16         # \ei\e_r
-  noback pass3    @1b-24-1b-4569-14                        @4569@16    # \ei\e_c
-  noback pass3    @1b-24-1b-4569-123                       @3456@16    # \ei\e_l
+  noback pass3    @1b-24-1b-456a-1235                      @16         # \ei\e_r
+  noback pass3    @1b-24-1b-456a-14                        @456a@16    # \ei\e_c
+  noback pass3    @1b-24-1b-456a-123                       @3456@16    # \ei\e_l
   noback pass3    @1b-24                                   ?           # \ei
   noback pass3    @1b-34-1235                              @4          # \e⠌r
   noback pass3    @1b-34-14                                @45         # \e⠌c


### PR DESCRIPTION
In dutch table changed the underscore virtual dot from 4569 to 456a with Liblouis 3.30 release. Without this change follow up in Liblouisutdml, 18 voluve math tests are failing. Fixes issue #106

Thanks Bert the help! :-):-)

Attila