### PR TITLE
Update Liblouis stable version number from 3.30.0 to 3.31.0 version with required build files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.30.0
+  LIBLOUIS_VERSION: 3.31.0
 
 jobs:
   build:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -12,7 +12,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.30.0
+  LIBLOUIS_VERSION: 3.31.0
 
 jobs:
   sanitizer:

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -29,7 +29,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.30.0
+ARG LIBLOUIS_VERSION=3.31.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.30.0
+ARG LIBLOUIS_VERSION=3.31.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \


### PR DESCRIPTION
Hi Boys,

@egli, @bertfrees, as it is usual after new Liblouis stable release publication, I updated Liblouis version number from 3.30.0 version to 3.31.0 version with following build files:
* Dockerfile.win32,
* Dockerfile.win64,
* .github/workflow/main.iml,
* .github/workflow/sanitizer.yml

My local system first upgraded Liblouis package to the new 3.31.0 stable version, and after this, before I doing build file changes, I ran a ./autogen.sh --prefix=/usr, ./configure --prefix=/usr, make, and a make check commands.
I verifyed the tests/test-suite.log, my local system I see following informations, hopefully online workflows produce similar results:
```
================================================
   liblouisutdml 2.13.0: tests/test-suite.log
================================================

# TOTAL: 386
# PASS:  205
# SKIP:  0
# XFAIL: 181
# FAIL:  0
# XPASS: 0
# ERROR: 0
```

If you have a little time, and all checks are passed, please approve and merge this very little PR to the master branch.

I suggesting if this is possible, perhaps oktober or december we publicate a new Liblouisutdml 2.13.0 release, because oldest 2.12.0 Liblouisutdml release supports only Liblouis 3.27 version (this is interesting for example with Windows builds, usual Linux distribution ships Liblouis newest releases).
An another possible strategy to we waiting 3.32 Liblouis release, and after 3.32 Liblouis release publication happening in december 2, have possibility december publicate the fresh Liblouisutdml 2.13.0 version with latest fresh Liblouis version.

Thank you the cooperation,

Attila