### PR TITLE
Update LiblouisUTDML workflow files to the latest awailable Liblouis stable version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.32.0
+  LIBLOUIS_VERSION: 3.33.0
 
 jobs:
   build:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -12,7 +12,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.32.0
+  LIBLOUIS_VERSION: 3.33.0
 
 jobs:
   sanitizer:

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -29,7 +29,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.32.0
+ARG LIBLOUIS_VERSION=3.33.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.32.0
+ARG LIBLOUIS_VERSION=3.33.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \


### PR DESCRIPTION
Hi Boys,

As usual, I updated the Liblouis stable version to the latest version 3.33.0 in the files below:
* Dockerfile.win32,
* Dockerfile.win64,
* .github/workflow/main.yml,
* .github/workflow/sanitizer.yml.

The following tests ran fine for me:
* ./autogen.sh, ./configure, make commands: passed
* Into the tests directory the make check command: passed (no change the passed, xfail, and fail tests numbers).

I hope all Github online workflows are passed after the pull request submitting.
If everithing looks good, feel free to merge this PR to the LiblouisUTDML master branch. :-):-)

Congratulate the new Liblouis release,

Attila