### PR TITLE
Dockerfile.win32, Dockerfile.win64, .github/workflows/main.yml, .github/workflows/sanitizer.yml: Change Liblouis stable version number to the new 3.34.0 stable version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.33.0
+  LIBLOUIS_VERSION: 3.34.0
 
 jobs:
   build:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -12,7 +12,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.33.0
+  LIBLOUIS_VERSION: 3.34.0
 
 jobs:
   sanitizer:

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -29,7 +29,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.33.0
+ARG LIBLOUIS_VERSION=3.34.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.33.0
+ARG LIBLOUIS_VERSION=3.34.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \


### PR DESCRIPTION
Hi Boys,

As it is usual, I updated Liblouis stable version number in LiblouisUTDML related workflow and Docker files to the latest stable 3.34.0 release.
Congratulate the new release, have lot of new improvements with various international languages.
If all online Github checks passed, please merge this PR to the master branch.
Me all local checks passed (the main source directory passed the ./autogen.sh, ./configure, make check commands), and passed the test directory the make check command.

Future we doing a new stable LiblouisUTDML stable version? I opened I think march an issue this task related, but not remember now the issue number. After Chris merged the 3.33.0 Liblouis version increase related PR, I think I opened the issue, but not remember now the issue report number. :-):-)

The most important thing:
If you can, get plenty of rest on the weekend, and if you celebrate Pentecost, I wish you a blessed Pentecost.

Attila