### PR TITLE
libxml_errors: drop ATTRIBUTE_UNUSED

### DIFF
--- a/liblouisutdml/liblouisutdml.c
+++ b/liblouisutdml/liblouisutdml.c
@@ -56,7 +56,7 @@ LBUAPI void EXPORT_CALL lbu_loadXMLCatalog(const char *filename)
   xmlLoadCatalog(filename);
 }
 void
-libxml_errors (void *ctx ATTRIBUTE_UNUSED, const char *msg, ...)
+libxml_errors (void *ctx, const char *msg, ...)
 {
   va_list args;
   char buffer[MAXNAMELEN];

--- a/liblouisutdml/louisutdml.h
+++ b/liblouisutdml/louisutdml.h
@@ -370,7 +370,7 @@ int do_blankline ();
 int do_softreturn ();
 int do_righthandpage ();
 int do_pagenum ();
-void libxml_errors (void *ctx ATTRIBUTE_UNUSED, const char *msg, ...);
+void libxml_errors (void *ctx, const char *msg, ...);
 int do_configstring (xmlNode * node);
 StyleType *new_style (xmlChar * name);
 StyleType *lookup_style (xmlChar * name);


### PR DESCRIPTION
libxml before 2.14 used to define it, but it's not part of its API, so we shouldn't have been using it.

Fixes #118