### PR TITLE
Dockerfile.win32, Dockerfile.win64: Fix cross-compile related issues

### DIFF
--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:bookworm@sha256:8738a0fdc7a61feebbeb625c41b405443639ea0a04ecc0d481d92b4720fd8566
 
 # This is a dockerfile that creates an environment to cross-compile
 # liblouisutdml for Windows. It includes libyaml and liblouis.
@@ -52,7 +52,7 @@ RUN ./bootstrap && \
 
 # Build and install libxml2
 WORKDIR ${SRCDIR}
-RUN curl -L ftp://xmlsoft.org/libxml2/libxml2-${LIBXML2_VERSION}.tar.gz | tar zx
+RUN curl -L http://xmlsoft.org/ftp/libxml2/libxml2-${LIBXML2_VERSION}.tar.gz | tar zx
 WORKDIR ${SRCDIR}/libxml2-${LIBXML2_VERSION}
 RUN autoreconf -i && \
     ./configure --with-zlib=no --with-iconv=no --with-python=no --with-threads=no --host ${HOST} --prefix=${PREFIX} && \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -1,4 +1,4 @@
-FROM debian:latest
+from debian:bookworm@sha256:b5fd0730c71f88a75e9d95dc6d812e8c34db679b3f009903d917be8f0300ba13
 
 # This is a dockerfile that creates an environment to cross-compile
 # liblouisutdml for Windows. It includes libyaml and liblouis.
@@ -44,7 +44,7 @@ RUN ./bootstrap && \
 
 # Build and install libxml2
 WORKDIR ${SRCDIR}
-RUN curl -L ftp://xmlsoft.org/libxml2/libxml2-${LIBXML2_VERSION}.tar.gz | tar zx
+RUN curl -L http://xmlsoft.org/ftp/libxml2/libxml2-${LIBXML2_VERSION}.tar.gz | tar zx
 WORKDIR ${SRCDIR}/libxml2-${LIBXML2_VERSION}
 RUN autoreconf -i && \
     ./configure --with-zlib=no --with-iconv=no --with-python=no --with-threads=no --host ${HOST} --prefix=${PREFIX} && \


### PR DESCRIPTION
Hi Boys,

In merged and closed pull request #123 Chris and I discussed various cross-compilation related issues and remaining tasks. :-):-)
Dockerfiles default now using original in Liblouisutdml with debian:latest images (this images always tagged with latest awailable  Debian stable release, now, this stable version is Debian 13).
Now, in Debian 13 release cross-compilation doesn't happened with various issues related:
* The libxml2 related URL is changed, previous used URL drops 404 status ansswer,
* Gnulib related files are not compatible anyway with Debian 13 now.

Now, more simpler to change back with building related image from debian:latest to with debian:bookworm related images.
Bookworm (Debian 12 version) are supported until 2028. june 30, so we have more time resolve gnulib related issue with cross-compilation related.
The libxml2 related URL I changed the correct URL.

The test results the fixed Docker files related:
* Make distwin me correct generated liblouisutdml-win32.zip, and liblouisutdml-win64.zip files.
* The 32 bit Liblouisutdml wine build is basically launch, but the HTML conversion are not working (known issue, already reported oldest time).
The 64 bit version wine build works correct.
For example after I defined LOUIS_TABLEPATH environment value, bin/lou_checkyaml command ran successfull the hungarian Liblouis larger test database test. Liblouis commands inside Liblouisutdml bin directory ran correct too.
The 64 bit version the HTML to Braille conversion works perfect with file2brl.exe command in Wine.
Me not have real Windows operating system my machines, so only I have possibility to test Liblouisutdml windows binaries into Wine emulator. :-):-)

Please merge this change to the master branch.
After the merge, we again we have taken a big step towards a new Liblouisutdml 2.13.0 stable version (the previous version was released in November 2023, ten Liblouis versions have been released since then, a new Liblouisutdml version should be need releasing future in due course due to the many Liblouis bug fixes and Braille tablet improvements.).

Of course, the anomaly related to the gnulib system in the Debian Trixie version for Docker cross-compilations must be resolved before June 30, 2028, but this task can be solved later, there is still plenty of time in the support period of Debian version 12.
The quality of Liblouisutdml is not affected by the fact that the Windows versions were created under Debian 12 rather than DEbian 13, the versions are the same.

Thank you the good cooperation,

Attila