### PR TITLE
Dockerfile.win32, Dockerfile.win64, .github/workflows/main.yml, .github/workflows/sanitizer.yml: Change Liblouis stable version number to the new 3.38.0 stable version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.37.0
+  LIBLOUIS_VERSION: 3.38.0
 
 jobs:
   build:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -12,7 +12,7 @@ on:
     branches: [ master ]
 
 env:
-  LIBLOUIS_VERSION: 3.37.0
+  LIBLOUIS_VERSION: 3.38.0
 
 jobs:
   sanitizer:

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -30,7 +30,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.37.0
+ARG LIBLOUIS_VERSION=3.38.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=i686-w64-mingw32 \
     PREFIX=/usr/build/win32 \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
-ARG LIBLOUIS_VERSION=3.37.0
+ARG LIBLOUIS_VERSION=3.38.0
 ARG LIBXML2_VERSION=2.9.9
 ENV HOST=x86_64-w64-mingw32 \
     PREFIX=/usr/build/win64 \


### PR DESCRIPTION
Hi Boys,

As it is usual, after new Liblouis 3.38.0 stable version are publicated, I updated Liblouis version namber from the 3.37.0 stable version to the 3.38.0 stable version with following affected files:
* Dockerfile.win32,
* Dockerfile.win64,
* .github/workflows/main.yml,
* .github/workflows/sanitizer.yml

Following tests are passed:
* ./autogen.sh --prefix=/usr, ./configure --prefix=/usr, make command: pass,
* Into the tests directory pass the make check command, not have failed tests.
Into the test-suite.log I see following result:
```
================================================
   liblouisutdml 2.13.0: tests/test-suite.log
================================================

# TOTAL: 386
# PASS:  205
# SKIP:  0
# XFAIL: 181
# FAIL:  0
# XPASS: 0
# ERROR: 0
```

A short question:
Have a determined Liblouisutdml 2.13.0 estimated release date? The 2.12.0 version are comed out in 2023. november 2.
The 2.12.0 Liblouisutdml release is contains Liblouis 3.27.0 version. This interesting in Windows, because Linux distros usual occasionally update Liblouis related packages.

Attila